### PR TITLE
fix recipe: kernel-module-gpio-button-hotplug

### DIFF
--- a/recipes-kernel/linux-4.14.95/kernel-module-gpio-button-hotplug/kernel-module-gpio-button-hotplug/Makefile
+++ b/recipes-kernel/linux-4.14.95/kernel-module-gpio-button-hotplug/kernel-module-gpio-button-hotplug/Makefile
@@ -4,6 +4,9 @@ obj-m := gpio-button-hotplug.o
 
 SRC := $(shell pwd)
 
+clean:
+	@rm *.o || true 
+
 all:
 	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
 

--- a/recipes-kernel/linux-4.14.95/kernel-module-gpio-button-hotplug/kernel-module-gpio-button-hotplug_git.bb
+++ b/recipes-kernel/linux-4.14.95/kernel-module-gpio-button-hotplug/kernel-module-gpio-button-hotplug_git.bb
@@ -10,5 +10,6 @@ inherit module
 S = "${WORKDIR}"
 
 FILES_${PN}${KERNEL_MODULE_PACKAGE_SUFFIX} += "/lib/firmware/*"
+FILES_${PN} += "/lib/modules"
 
 KERNEL_MODULE_AUTOLOAD += "kernel-module-gpio-button-hotplug"


### PR DESCRIPTION
Changes:
- Create a clean rule in Makefile
- QA: explicit ship /lib/modules in kernel-module-gpio-button-hotplug